### PR TITLE
Remove unused cdist import

### DIFF
--- a/curve_memory_tsp.py
+++ b/curve_memory_tsp.py
@@ -1,5 +1,4 @@
 import numpy as np
-from scipy.spatial.distance import cdist
 from typing import Callable, List, Tuple
 
 class CurveMemoryTSPSolver:


### PR DESCRIPTION
## Summary
- clean up `curve_memory_tsp` by dropping unused `cdist` import

## Testing
- `python -m py_compile curve_memory_tsp.py`

------
https://chatgpt.com/codex/tasks/task_e_6841794be0f4832faa17be2ec3f45a32